### PR TITLE
Added Logistic Regression to predict stock market trend

### DIFF
--- a/BWR_05_Features.ecl
+++ b/BWR_05_Features.ecl
@@ -1,0 +1,39 @@
+IMPORT StockData;
+IMPORT Std;
+
+#WORKUNIT('name', 'Stock Data: Enhance Cleaned Data W Full Features');
+
+baseData := StockData.Files.Enhanced.ds;
+
+enhancedData1 := PROJECT
+    (
+        baseData,
+        TRANSFORM
+            (
+                StockData.Files.Features.Layout,
+                SELF := LEFT,
+                SELF := []
+            )
+    );
+
+groupedData := GROUP(SORT(enhancedData1, symbol, trade_date), symbol);
+
+withChanges := ITERATE
+    (
+        groupedData,
+        TRANSFORM
+            (
+                RECORDOF(LEFT),
+                SELF.shares_traded_change_rate := RIGHT.shares_traded_change / LEFT.shares_traded,
+                SELF.direction := MAP(
+                                        RIGHT.closing_price_change < 0 =>0,
+                                        RIGHT.closing_price_change > 0 => 1, 2), 
+                SELF := RIGHT)
+    );
+
+ungroupedData := UNGROUP(withChanges);
+
+OUTPUT(ungroupedData, /*RecStruct*/, StockData.Files.Features.PATH, OVERWRITE, COMPRESSED);
+
+working_data := PROJECT(ungroupedData, TRANSFORM(StockData.Files.Preprocessing.Layout,
+                                                SELF := LEFT));

--- a/BWR_06_LogisticRegression.ecl
+++ b/BWR_06_LogisticRegression.ecl
@@ -1,0 +1,59 @@
+IMPORT StockData;
+IMPORT ML_Core;
+IMPORT ML_Core.Types AS Types;
+IMPORT ML_Core.Analysis;
+IMPORT LogisticRegression AS LR;
+IMPORT Std;
+
+#WORKUNIT('name', 'Stock Data: Logistic Regression - Singel Wi');
+
+TRADE_START_DATE := StockData.Files.TRADE_START_DATE;
+TRADE_END_DATE := StockData.Files.TRADE_END_DATAE;
+
+//Select Apple Stock (Stock_Symbol: 'AAPL', Exchange: 'O') to run regression.
+exchange_code := 'O';
+stock_symbol := 'AAPL';
+baseData := StockData.Files.Features.ds( stock_symbol = 'AAPL' AND (direction = 0 OR direction = 1));
+//Valid Trading Dates
+tradeperiod := StockData.Files.Summarized.ds(symbol = StockData.Util.MakeFullSymbol(exchange_code, stock_symbol));
+first_seen := tradeperiod[1].first_seen_date; // 20020101
+last_seen := tradeperiod[1].last_seen_date; // 20181101
+trainstart_date := IF(first_seen <= TRADE_START_DATE, TRADE_START_DATE, first_seen); //20020108
+trainend_date := 20180101;
+teststart_date := MAX(trainend_date, TRADE_START_DATE);
+end_date := 20180601;
+testend_date := MIN(end_date, TRADE_END_DATE);
+
+//Transform baseData to NF format.
+ML_Core.AppendID(baseData, id, dsID);
+dsTrain := dsID(trade_date < trainend_date AND trade_date > trainstart_date);
+dstest := dsID(trade_date <= testend_date AND trade_date >= teststart_date);
+ML_Core.ToField(dstrain, NFtrain, id,, ,'opening_price_change,closing_price_change,shares_traded_change_rate, direction');
+ML_Core.ToField(dstest, NFtest, id,, ,'opening_price_change,closing_price_change,shares_traded_change_rate, direction');
+//Helper: Scaler
+Scaler(DATASET(Types.NumericField) ds) := FUNCTION
+  scale:= ML_Core.FieldAggregates(ds).simple;
+  rst := JOIN(ds, scale, LEFT.wi = RIGHT.wi AND LEFT.number = RIGHT.number,  TRANSFORM(Types.NumericField, 
+              SELF.value := (LEFT.value - RIGHT.minval)/(RIGHT.maxval- RIGHT.minval), SELF := LEFT), LOOKUP);
+RETURN rst;
+END;
+//Preproceessing
+pfield := 4;
+//Trainset
+DStrainInd := NFtrain(number < pfield);
+DStrainInd_scaled:= scaler(dstrainind);
+DStrainDpt := PROJECT(NFtrain(number = pfield ), TRANSFORM(Types.DiscreteField, SELF.number := 1, SELF := LEFT));
+//Testset
+DStestInd := NFtest(number < pfield);
+DStestInd_scaled := scaler(DStestInd);
+DStestDpt :=  PROJECT(NFtest(number = pfield ), TRANSFORM(Types.DiscreteField, SELF.number := 1, SELF := LEFT));
+//LogisticRegression
+mod_bi := LR.BinomialLogisticRegression(100, 0.0000001).getModel(DStrainInd_scaled, DStrainDpt);
+//Prediction
+classesstat := Analysis.Classification.ClassStats(DSTrainDpt);
+OUTPUT(classesstat , NAMED('classesstats'));
+prediction  := LR.BinomialLogisticRegression(100, 0.0000001).Classify(mod_bi,DStestInd_scaled);
+OUTPUT(prediction   , NAMED('prediction'));
+//Analysis
+evaluation := Analysis.Classification.AccuracyByClass(prediction, DSTestDpt);
+OUTPUT(evaluation, NAMED('evaluation'));

--- a/Files.ecl
+++ b/Files.ecl
@@ -3,6 +3,8 @@ IMPORT Std;
 EXPORT Files := MODULE
 
     EXPORT PATH_PREFIX := '~dcamper::stock_data';
+    EXPORT TRADE_START_DATE := 20020108;
+    EXPORT TRADE_END_DATAE:= 20181101;
 
     //--------------------------------------------------------------------------
 
@@ -151,5 +153,37 @@ EXPORT Files := MODULE
         EXPORT ds := DATASET(PATH, Layout, FLAT);
 
     END; // Summarized module
+        EXPORT PATH_PREFIX1 := '~thor::lilix::Stock_Data';
+    EXPORT Features := MODULE
+
+        EXPORT Layout := RECORD(Enhanced.Layout)
+            REAL4              shares_traded_change_rate; // Volume Change rate in volume as 
+                                                          //compared to previous day
+            UNSIGNED4          direction;                 //0->down; 1-->up; 2-->even           
+        END;
+
+        EXPORT PATH := PATH_PREFIX1 + '::full_data';
+
+        EXPORT ds := DATASET(PATH, Layout, FLAT);
+    END;
+
+    EXPORT Preprocessing := MODULE
+
+        EXPORT Layout := RECORD
+            Enhanced.Layout.opening_price_change;
+            Enhanced.Layout.closing_price_change;
+            Enhanced.Layout.moving_ave_opening_price;
+            Enhanced.Layout.moving_ave_high_price;
+            Enhanced.Layout.moving_ave_low_price;
+            Enhanced.Layout.moving_ave_closing_price;       
+            Features.Layout.shares_traded_change_rate;
+            Features.Layout.direction;
+        END;
+
+        EXPORT PATH := PATH_PREFIX1 + '::WORKING_Data';
+        
+        EXPORT ds := DATASET(PATH, Layout, FLAT);
+    END;
+
 
 END;


### PR DESCRIPTION
Apply Logistic Regression to predict stock market trend on HPCC Systems platform. The algorithm can be found via below link:
[HPCC Systems Machine Learning Library](https://hpccsystems.com/download/free-modules/machine-learning-library)

